### PR TITLE
Terragrunt (tgplan) and Github SSH Compatibility 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN curl --location https://github.com/accurics/terrascan/releases/download/v${T
     mv terrascan /usr/bin/ && \
     terrascan version
 
+# Github clone by ssh compatibility    
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]    
+
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN curl --location https://github.com/accurics/terrascan/releases/download/v${T
     rm -f terrascan.tar.gz && \
     mv terrascan /usr/bin/ && \
     terrascan version
-    
-    
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The Accurics GitHub action runs as a Linux container, which means it accumulates
 | scan-mode | Allows the Accurics Action to use either terraform or terrascan for scanning(plan/scan) | plan |
 | url | Allows the Accurics Action to point to different target endpoint of the product e.g. https://cloud.tenable.com/cns | https://app.accurics.com |
 | pipeline | Allows the Accurics Action to choose mode as pipeline | false |
-
+| run-mode | Allows run terragrunt or terraform (plan/tgplan) | plan |
+| terragrunt-version | Allows install terragrunt DRY Terraform |  |
 
 ### Notes
 - Variable values within the plan-args setting should be stripped of double-quote (") characters

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,14 @@ inputs:
     description: 'Allows Accurics to put data into pipeline tab in tenable.cs web consile values accepted(true/false)'
     required: false
     default: false
+  run-mode:
+    description: 'Allows run terragrunt or terraform (plan/tgplan)'
+    required: false
+    default: "plan"
+  terragrunt-version:
+    description: 'Allows install terragrunt DRY Terraform'
+    required: false
+    default: ""
 outputs:
   env-name:
     description: 'Environment Name'
@@ -96,4 +104,6 @@ runs:
     - ${{ inputs.fail-on-all-errors }}
     - ${{ inputs.scan-mode }}
     - ${{ inputs.pipeline }}
+    - ${{ inputs.run-mode }}
+    - ${{ inputs.terragrunt-version }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ process_args() {
   INPUT_FAIL_ON_ALL_ERRORS=${10}
   INPUT_SCAN_MODE=${11}
   INPUT_PIPELINE=${12}
+  INPUT_RUN_MODE=${13}
+  INPUT_TERRAGRUNT_VERSION=${14}
 
   # If all config parameters are specified, use the config params passed in instead of the config file checked into the repository
   [ "$INPUT_ENV_ID" = "" ]    && echo "Error: The env-id parameter is required and not set." && exit 1
@@ -27,6 +29,30 @@ process_args() {
   export ACCURICS_ENV_ID=$INPUT_ENV_ID
   export ACCURICS_APP_ID=$INPUT_APP_ID
   export ACCURICS_REPO_NAME=$INPUT_REPO_NAME
+}
+
+install_terragrunt() {
+  local tgVersion=$1
+  local url
+  url="https://github.com/gruntwork-io/terragrunt/releases/download/${tgVersion}/terragrunt_linux_amd64"
+ 
+  echo "Downloading Terragrunt ${tgVersion}"
+  curl -s -S -L -o /tmp/terragrunt ${url}
+  if [ "${?}" -ne 0 ]; then
+    echo "Failed to download Terragrunt ${tgVersion}"
+    exit 1
+  fi
+  echo "Successfully downloaded Terragrunt ${tgVersion}"
+
+  echo "Moving Terragrunt ${tgVersion} to PATH"
+  chmod +x /tmp/terragrunt
+  mv /tmp/terragrunt /usr/local/bin/terragrunt 
+  if [ "${?}" -ne 0 ]; then
+    echo "Failed to move Terragrunt ${tgVersion}"
+    exit 1
+  fi
+  echo "Successfully moved Terragrunt ${tgVersion}"
+  
 }
 
 install_terraform() {
@@ -62,8 +88,7 @@ run_accurics() {
      echo "running plan mode"
      accurics init
   fi
-  
-   
+
   if [ "$INPUT_PIPELINE" = true ]; then
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
      echo "running pipeline mode"
@@ -71,9 +96,9 @@ run_accurics() {
   else
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
-  
+
    # Run accurics plan
-  accurics $runMode $params $plan_args $pipeline_mode
+  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
 
   ACCURICS_PLAN_ERR=$?
 }
@@ -123,9 +148,18 @@ process_output() {
 INPUT_DEBUG_MODE=$1
 [ "$INPUT_DEBUG_MODE" = "true" ] && set -x
 
-process_args "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}"
+process_args "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}" "${13}" "${14}" 
 
 install_terraform $INPUT_TERRAFORM_VERSION
+
+if [[ "${INPUT_RUN_MODE}" == "tgplan" ]]; then
+  echo "line 156" $?
+  echo "Installing kubegrunt and terragrunt"
+  install_terragrunt $INPUT_TERRAGRUNT_VERSION
+fi
+
+#2.35.2 github update
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
 for d in $INPUT_DIRECTORIES; do
   cd $d
@@ -135,8 +169,9 @@ for d in $INPUT_DIRECTORIES; do
   echo "======================================================================"
   echo " Running the Accurics Action for directory: "
   echo "   $d"
+  echo " Github_workspace  $GITHUB_WORKSPACE"
   echo "======================================================================"
-
+  
   run_accurics "$run_params" "$INPUT_PLAN_ARGS"
 
   echo "======================================================================"


### PR DESCRIPTION
What does this do?
- Allows accurics to do an IAC vulnerability scan on manifests made in terragrunt.
- Install the desired terragrunt version only if I select tgplan
- This does not include tgplanAll

In addition:
- Github clone by ssh compatibility 

Evidence of use
- Github action step implemented

![Screen Shot 2022-05-24 at 09 54 41](https://user-images.githubusercontent.com/19688747/170079448-5eb50911-9f13-4355-960e-9bbfceafa34f.png)

- Workflow running
![Screen Shot 2022-05-24 at 09 57 29](https://user-images.githubusercontent.com/19688747/170080061-140f1366-19ee-43a7-8a32-c70603fd69e0.png)

