### PR TITLE
APE-8931 :- TF_CLI_CONFIG_FILE env variable is not respected in accurics scan/terrascan 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM alpine:3.13
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 
-ARG TERRASCAN_VERSION=1.15.0
-ARG CLI_VERSION=1.0.37
+ARG TERRASCAN_VERSION=1.15.2
+ARG CLI_VERSION=1.0.41
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
   curl -s https://downloads.accurics.com/cli/dev/${CLI_VERSION}/accurics_linux -o /usr/bin/accurics && \
   chmod 755 /entrypoint.sh /usr/bin/accurics

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,11 +63,11 @@ run_accurics() {
      accurics init
   fi
   
-  echo "forcing TF_CLI_CONFIG_FILE"
-  export TF_CLI_CONFIG_FILE=.terraformrc
-  echo "value of TF_CLI_CONFIG_FILE=$TF_CLI_CONFIG_FILE"
-  echo $TF_CLI_CONFIG_FILE
-  echo "GITHUB_ENV:$GITHUB_ENV"
+#   echo "forcing TF_CLI_CONFIG_FILE"
+#   export TF_CLI_CONFIG_FILE=.terraformrc
+#   echo "value of TF_CLI_CONFIG_FILE=$TF_CLI_CONFIG_FILE"
+#   echo $TF_CLI_CONFIG_FILE
+#   echo "GITHUB_ENV:$GITHUB_ENV"
   
   #echo "TF_CLI_CONFIG_FILE=.terraformrc" >> $GITHUB_ENV
   #echo "GITHUB_ENV:$GITHUB_ENV"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,18 +63,6 @@ run_accurics() {
      accurics init
   fi
   
-#   echo "forcing TF_CLI_CONFIG_FILE"
-#   export TF_CLI_CONFIG_FILE=.terraformrc
-#   echo "value of TF_CLI_CONFIG_FILE=$TF_CLI_CONFIG_FILE"
-#   echo $TF_CLI_CONFIG_FILE
-#   echo "GITHUB_ENV:$GITHUB_ENV"
-  
-  #echo "TF_CLI_CONFIG_FILE=.terraformrc" >> $GITHUB_ENV
-  #echo "GITHUB_ENV:$GITHUB_ENV"
-  #echo "printing content of file"
-  #cat  .terraformrc
-  #echo "printing content of file"
-  #cat ./.terraformrc
   echo "TF_CLI_CONFIG_FILE:$TF_CLI_CONFIG_FILE"
   
   if [ "$INPUT_PIPELINE" = true ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,6 +71,10 @@ run_accurics() {
   
   echo "TF_CLI_CONFIG_FILE=.terraformrc" >> $GITHUB_ENV
   echo "GITHUB_ENV:$GITHUB_ENV"
+  echo "printing content of file"
+  cat  .terraformrc
+  echo "printing content of file"
+  cat ./.terraformrc
   
   if [ "$INPUT_PIPELINE" = true ]; then
      echo "INPUT_PIPELINE="$INPUT_PIPELINE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,6 +67,10 @@ run_accurics() {
   export TF_CLI_CONFIG_FILE=.terraformrc
   echo "value of TF_CLI_CONFIG_FILE=$TF_CLI_CONFIG_FILE"
   echo $TF_CLI_CONFIG_FILE
+  echo "GITHUB_ENV:$GITHUB_ENV"
+  
+  echo "TF_CLI_CONFIG_FILE=.terraformrc" >> $GITHUB_ENV
+  echo "GITHUB_ENV:$GITHUB_ENV"
   
   if [ "$INPUT_PIPELINE" = true ]; then
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
@@ -77,7 +81,7 @@ run_accurics() {
   fi
   
    # Run accurics plan
-  accurics $runMode $params $plan_args $pipeline_mode
+  TF_CLI_CONFIG_FILE=.terraformrc accurics $runMode $params $plan_args $pipeline_mode
 
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,11 @@ run_accurics() {
      accurics init
   fi
   
-   
+  echo "forcing TF_CLI_CONFIG_FILE"
+  export TF_CLI_CONFIG_FILE=.terraformrc
+  echo "value of TF_CLI_CONFIG_FILE=$TF_CLI_CONFIG_FILE"
+  echo $TF_CLI_CONFIG_FILE
+  
   if [ "$INPUT_PIPELINE" = true ]; then
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
      echo "running pipeline mode"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,12 +69,13 @@ run_accurics() {
   echo $TF_CLI_CONFIG_FILE
   echo "GITHUB_ENV:$GITHUB_ENV"
   
-  echo "TF_CLI_CONFIG_FILE=.terraformrc" >> $GITHUB_ENV
-  echo "GITHUB_ENV:$GITHUB_ENV"
-  echo "printing content of file"
-  cat  .terraformrc
-  echo "printing content of file"
-  cat ./.terraformrc
+  #echo "TF_CLI_CONFIG_FILE=.terraformrc" >> $GITHUB_ENV
+  #echo "GITHUB_ENV:$GITHUB_ENV"
+  #echo "printing content of file"
+  #cat  .terraformrc
+  #echo "printing content of file"
+  #cat ./.terraformrc
+  echo "TF_CLI_CONFIG_FILE:$TF_CLI_CONFIG_FILE"
   
   if [ "$INPUT_PIPELINE" = true ]; then
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
@@ -85,7 +86,7 @@ run_accurics() {
   fi
   
    # Run accurics plan
-  TF_CLI_CONFIG_FILE=.terraformrc accurics $runMode $params $plan_args $pipeline_mode
+  accurics $runMode $params $plan_args $pipeline_mode
 
   ACCURICS_PLAN_ERR=$?
 }


### PR DESCRIPTION
Latest terrascan v1.15.2 shipped as the older one was not respecting TF_CLI_CONFIG_FILE
Ship latest terrascan v1.15.2
