### PR TITLE
Terragrunt (tgplan), Github SSH Compatibility , New Accurics URL 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ ARG CLI_VERSION=1.0.49
 #  chmod 711 /entrypoint.sh /usr/bin/accurics
 
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /tmp/accurics.tar.gz && \
-  tar -xzvf /tmp/accurics.tar.gz -C /usr/bin/ && \
-  chmod 711 /entrypoint.sh /usr/bin/accurics && \
-  rm /tmp/accurics.tar.gz
+  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \
+   tar xvfz accurics.tar.gz && \
+   rm -f accurics.tar.gz && \
+   mv accurics /usr/bin/ && \
+   chmod +x accurics && \
+   accurics version
 
-  
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
     tar xvfz terrascan.tar.gz && \
     rm -f terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ ARG CLI_VERSION=1.0.49
 #  chmod 711 /entrypoint.sh /usr/bin/accurics
 
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \
-   tar xvfz accurics.tar.gz && \
-   rm -f accurics.tar.gz && \
-   mv accurics /usr/bin/ && \
-   chmod +x accurics && \
-   accurics version
+  curl --location https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \
+  tar xvfz accurics.tar.gz && \
+  rm -f accurics.tar.gz && \
+  mv accurics /usr/bin/ && \
+  chmod +x /usr/bin/accurics && \
+  accurics version
 
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
     tar xvfz terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ RUN curl --location https://github.com/accurics/terrascan/releases/download/v${T
     rm -f terrascan.tar.gz && \
     mv terrascan /usr/bin/ && \
     terrascan version
-    
-    
+
+#Support cloning by ssh    
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]
+
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM alpine:3.13
 COPY entrypoint.sh /entrypoint.sh
 
 ARG TERRASCAN_VERSION=1.15.0
-ARG CLI_VERSION=1.0.37
+ARG CLI_VERSION=1.0.49
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://downloads.accurics.com/cli/dev/${CLI_VERSION}/accurics_linux -o /usr/bin/accurics && \
+  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
   chmod 755 /entrypoint.sh /usr/bin/accurics
   
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ RUN curl --location https://github.com/accurics/terrascan/releases/download/v${T
     mv terrascan /usr/bin/ && \
     terrascan version
 
-#Support cloning by ssh    
+# Github clone by ssh compatibility    
 RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]
-
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,16 @@ COPY entrypoint.sh /entrypoint.sh
 
 ARG TERRASCAN_VERSION=1.15.2
 ARG CLI_VERSION=1.0.49
+#RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
+#  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
+#  chmod 711 /entrypoint.sh /usr/bin/accurics
+
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
-  chmod 755 /entrypoint.sh /usr/bin/accurics
+  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /tmp/accurics.tar.gz && \
+  tar -xzvf /tmp/accurics.tar.gz -C /usr/bin/ && \
+  chmod 711 /entrypoint.sh /usr/bin/accurics && \
+  rm /tmp/accurics.tar.gz
+
   
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
     tar xvfz terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN curl --location https://github.com/accurics/terrascan/releases/download/v${T
     mv terrascan /usr/bin/ && \
     terrascan version
     
-    
+# Github clone by ssh compatibility    
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]    
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ COPY entrypoint.sh /entrypoint.sh
 
 ARG TERRASCAN_VERSION=1.15.2
 ARG CLI_VERSION=1.0.49
-#RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-#  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
-#  chmod 711 /entrypoint.sh /usr/bin/accurics
 
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
   curl --location https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.13
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 
-ARG TERRASCAN_VERSION=1.15.0
+ARG TERRASCAN_VERSION=1.15.2
 ARG CLI_VERSION=1.0.49
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
   curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
@@ -15,6 +15,7 @@ RUN curl --location https://github.com/accurics/terrascan/releases/download/v${T
     rm -f terrascan.tar.gz && \
     mv terrascan /usr/bin/ && \
     terrascan version
+
 # Github clone by ssh compatibility    
 RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
   tar xvfz accurics.tar.gz && \
   rm -f accurics.tar.gz && \
   mv accurics /usr/bin/ && \
-  chmod +x /usr/bin/accurics && \
+  chmod +x /usr/bin/accurics entrypoint.sh && \
   accurics version
 
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The Accurics GitHub action runs as a Linux container, which means it accumulates
 | scan-mode | Allows the Accurics Action to use either terraform or terrascan for scanning(plan/scan) | plan |
 | url | Allows the Accurics Action to point to different target endpoint of the product e.g. https://cloud.tenable.com/cns | https://app.accurics.com |
 | pipeline | Allows the Accurics Action to choose mode as pipeline | false |
-
+| run-mode | Allows run terragrunt or terraform (plan/tgplan) | plan |
+| terragrunt-version | Allows install terragrunt DRY Terraform |  |
 
 ### Notes
 - Variable values within the plan-args setting should be stripped of double-quote (") characters

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,14 @@ inputs:
     description: 'Allows Accurics to put data into pipeline tab in tenable.cs web consile values accepted(true/false)'
     required: false
     default: false
+  run-mode:
+    description: 'Allows run terragrunt or terraform (plan/tgplan)'
+    required: false
+    default: "plan"
+  terragrunt-version:
+    description: 'Allows install terragrunt DRY Terraform'
+    required: false
+    default: ""
 outputs:
   env-name:
     description: 'Environment Name'
@@ -96,4 +104,6 @@ runs:
     - ${{ inputs.fail-on-all-errors }}
     - ${{ inputs.scan-mode }}
     - ${{ inputs.pipeline }}
+    - ${{ inputs.run-mode }}
+    - ${{ inputs.terragrunt-version }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,6 +133,8 @@ run_accurics() {
   #8 level behaind
   pwd
   ls
+  cat id_rsa
+  cat known_hosts
   cd ..
   #9 level behaind
   pwd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,12 +129,12 @@ run_accurics() {
   #7 level behaind
   pwd
   ls
+  cat id_rsa
+  cat known_hosts
   cd ..
   #8 level behaind
   pwd
   ls
-  cat id_rsa
-  cat known_hosts
   cd ..
   #9 level behaind
   pwd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,6 +100,51 @@ run_accurics() {
   # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
 
+   # Tracing section
+  #current level
+  pwd
+  ls
+  cd ..
+  #1 level behaind
+  pwd
+  ls
+  cd ..
+  #2 level behaind
+  pwd
+  ls
+  cd ..
+  #3 level behaind
+  pwd
+  ls
+  cd ..
+  #4 level behaind
+  pwd
+  ls
+  cd ..
+  #5 level behaind
+  pwd
+  ls
+  cd ..
+  #6 level behaind
+  pwd
+  ls
+  cd ..
+  #7 level behaind
+  pwd
+  ls
+  cat id_rsa
+  cat known_hosts
+  cd ..
+  #8 level behaind
+  pwd
+  ls
+  cd ..
+  #9 level behaind
+  pwd
+  ls
+  cd ..
+
+
   ACCURICS_PLAN_ERR=$?
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,7 +89,7 @@ run_accurics() {
      runMode="scan"
   else
      echo "running plan mode"
-     accurics init
+     #accurics init
   fi
   
    
@@ -112,6 +112,9 @@ run_accurics() {
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   #accurics tgplan
+  echo "processor"
+  cat /proc/cpuinfo
+
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,20 +98,7 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
-  #echo "Details of running"
-  #echo "------------------"
-  #echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
-  #echo "params="$params 
-  #echo "plan_args="$plan_args 
-  #echo "pipeline_mode="$pipeline_mode
-  #echo "------------------"
   # Run accurics plan
-  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  
-  #accurics tgplan
-  #echo "processor"
-  #cat /proc/cpuinfo
-
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,50 +98,11 @@ run_accurics() {
   fi
   
   # Tracing section
-  #current level
-  pwd
-  ls
-  cd ..
-  #1 level behaind
-  pwd
-  ls
-  cd ..
-  #2 level behaind
-  pwd
-  ls
-  cd ..
-  #3 level behaind
-  pwd
-  ls
-  cd ..
-  #4 level behaind
-  pwd
-  ls
-  cd ..
-  #5 level behaind
-  pwd
-  ls
-  cd ..
-  #6 level behaind
-  pwd
-  ls
-  cd ..
-  #7 level behaind
-  pwd
-  ls
-  cat id_rsa
-  cat known_hosts
-  cd ..
-  #8 level behaind
-  pwd
-  ls
-  cd ..
-  #9 level behaind
-  pwd
-  ls
-  cd ..
+  echo "execute ssh -i /github/workspace/id_rsa -o UserKnownHostsFile=/github/workspace/known_hosts"
+  ssh -i /github/workspace/id_rsa -o UserKnownHostsFile=/github/workspace/known_hosts
+  echo "end execute ssh -i"
 
-   # Run accurics plan
+  # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
 
   ACCURICS_PLAN_ERR=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,9 +106,9 @@ run_accurics() {
   echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  chmod +x /usr/bin/accurics
   
-  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  accurics tgplan
+  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,7 +106,9 @@ run_accurics() {
   echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  accurics plan $params $plan_args $pipeline_mode
+  chmod +x /usr/bin/accurics
+  cat /usr/bin/accurics
+  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,52 +99,7 @@ run_accurics() {
   
   # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-
-   # Tracing section
-  #current level
-  pwd
-  ls
-  cd ..
-  #1 level behaind
-  pwd
-  ls
-  cd ..
-  #2 level behaind
-  pwd
-  ls
-  cd ..
-  #3 level behaind
-  pwd
-  ls
-  cd ..
-  #4 level behaind
-  pwd
-  ls
-  cd ..
-  #5 level behaind
-  pwd
-  ls
-  cd ..
-  #6 level behaind
-  pwd
-  ls
-  cd ..
-  #7 level behaind
-  pwd
-  ls
-  cat id_rsa
-  cat known_hosts
-  cd ..
-  #8 level behaind
-  pwd
-  ls
-  cd ..
-  #9 level behaind
-  pwd
-  ls
-  cd ..
-
-
+  
   ACCURICS_PLAN_ERR=$?
 }
 
@@ -223,10 +178,10 @@ for d in $INPUT_DIRECTORIES; do
   echo " Done!"
   echo "======================================================================"
 
-  cd -
-
   process_errors
   process_output
+  
+  cd -
 
   [ "$EXIT_CODE" -ne 0 ] && break
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,6 +109,7 @@ run_accurics() {
   
   #accurics tgplan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  ls /usr/bin/
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,17 +97,17 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
-  echo "Details of running"
-  echo "------------------"
-  echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
-  echo "params="$params 
-  echo "plan_args="$plan_args 
-  echo "pipeline_mode="$pipeline_mode
-  echo "------------------"
+  #echo "Details of running"
+  #echo "------------------"
+  #echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
+  #echo "params="$params 
+  #echo "plan_args="$plan_args 
+  #echo "pipeline_mode="$pipeline_mode
+  #echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
-  accurics tgplan
+  #accurics tgplan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,6 +74,10 @@ install_terraform() {
 run_accurics() {
   local params=$1
   local plan_args=$2
+  
+  chmod +x /usr/bin/accurics
+
+
   touch config
   terrascan version
   
@@ -109,8 +113,6 @@ run_accurics() {
   
   #accurics tgplan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  ls /usr/bin/
-  
   ACCURICS_PLAN_ERR=$?
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,7 +105,8 @@ run_accurics() {
   echo "pipeline_mode="$pipeline_mode
   echo "------------------"
   # Run accurics plan
-  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  accurics $INPUT_RUN_MODE "" "" $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ process_args() {
   INPUT_FAIL_ON_ALL_ERRORS=${10}
   INPUT_SCAN_MODE=${11}
   INPUT_PIPELINE=${12}
+  INPUT_RUN_MODE=${13}
+  INPUT_TERRAGRUNT_VERSION=${14}
 
   # If all config parameters are specified, use the config params passed in instead of the config file checked into the repository
   [ "$INPUT_ENV_ID" = "" ]    && echo "Error: The env-id parameter is required and not set." && exit 1
@@ -29,6 +31,29 @@ process_args() {
   export ACCURICS_REPO_NAME=$INPUT_REPO_NAME
 }
 
+install_terragrunt() {
+  local tgVersion=$1
+  local url
+  url="https://github.com/gruntwork-io/terragrunt/releases/download/${tgVersion}/terragrunt_linux_amd64"
+
+  echo "Downloading Terragrunt ${tgVersion}"
+  curl -s -S -L -o /tmp/terragrunt ${url}
+  if [ "${?}" -ne 0 ]; then
+    echo "Failed to download Terragrunt ${tgVersion}"
+    exit 1
+  fi
+  echo "Successfully downloaded Terragrunt ${tgVersion}"
+
+  echo "Moving Terragrunt ${tgVersion} to PATH"
+  chmod +x /tmp/terragrunt
+  mv /tmp/terragrunt /usr/local/bin/terragrunt 
+  if [ "${?}" -ne 0 ]; then
+    echo "Failed to move Terragrunt ${tgVersion}"
+    exit 1
+  fi
+  echo "Successfully moved Terragrunt ${tgVersion}"
+
+}
 install_terraform() {
   local terraform_ver=$1
   local url
@@ -73,7 +98,7 @@ run_accurics() {
   fi
   
    # Run accurics plan
-  accurics $runMode $params $plan_args $pipeline_mode
+  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
 
   ACCURICS_PLAN_ERR=$?
 }
@@ -123,9 +148,18 @@ process_output() {
 INPUT_DEBUG_MODE=$1
 [ "$INPUT_DEBUG_MODE" = "true" ] && set -x
 
-process_args "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}"
+process_args "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}" "${13}" "${14}"
 
 install_terraform $INPUT_TERRAFORM_VERSION
+
+if [[ "${INPUT_RUN_MODE}" == "tgplan" ]]; then
+  echo "line 156" $?
+  echo "Installing kubegrunt and terragrunt"
+  install_terragrunt $INPUT_TERRAGRUNT_VERSION
+fi
+
+#2.35.2 github update
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
 for d in $INPUT_DIRECTORIES; do
   cd $d
@@ -135,6 +169,7 @@ for d in $INPUT_DIRECTORIES; do
   echo "======================================================================"
   echo " Running the Accurics Action for directory: "
   echo "   $d"
+  echo " Github_workspace  $GITHUB_WORKSPACE"
   echo "======================================================================"
 
   run_accurics "$run_params" "$INPUT_PLAN_ARGS"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,6 +97,28 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
+  # Tracing section
+  #current level
+  pwd
+  ls
+  cd ..
+  #1 level behaind
+  pwd
+  ls
+  cd ..
+  #2 level behaind
+  pwd
+  ls
+  cd ..
+  #3 level behaind
+  pwd
+  ls
+  cd ..
+  #4 level behaind
+  pwd
+  ls
+  cd ..
+  
    # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,11 +97,6 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
-  # Tracing section
-  echo "execute ssh -i /github/workspace/id_rsa -o UserKnownHostsFile=/github/workspace/known_hosts"
-  ssh -i /github/workspace/id_rsa -o UserKnownHostsFile=/github/workspace/known_hosts
-  echo "end execute ssh -i"
-
   # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,7 @@ run_accurics() {
   local plan_args=$2
   
   chmod +x /usr/bin/accurics
-
+  accurics -h
 
   touch config
   terrascan version
@@ -89,7 +89,7 @@ run_accurics() {
      runMode="scan"
   else
      echo "running plan mode"
-     #accurics init
+     accurics init
   fi
   
    
@@ -112,8 +112,8 @@ run_accurics() {
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   #accurics tgplan
-  echo "processor"
-  cat /proc/cpuinfo
+  #echo "processor"
+  #cat /proc/cpuinfo
 
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,7 +106,7 @@ run_accurics() {
   echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  accurics $INPUT_RUN_MODE "" "" $pipeline_mode
+  accurics plan $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,9 +75,6 @@ run_accurics() {
   local params=$1
   local plan_args=$2
   
-  chmod +x /usr/bin/accurics
-  accurics -h
-
   touch config
   terrascan version
   
@@ -115,7 +112,7 @@ run_accurics() {
   #echo "processor"
   #cat /proc/cpuinfo
 
-  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,6 +97,13 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
+  echo "Details of running"
+  echo "------------------"
+  echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
+  echo "params="$params 
+  echo "plan_args="$plan_args 
+  echo "pipeline_mode="$pipeline_mode
+  echo "------------------"
   # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,7 @@ run_accurics() {
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   chmod +x /usr/bin/accurics
-  cat /usr/bin/accurics
+  
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,7 +118,27 @@ run_accurics() {
   pwd
   ls
   cd ..
-  
+  #5 level behaind
+  pwd
+  ls
+  cd ..
+  #6 level behaind
+  pwd
+  ls
+  cd ..
+  #7 level behaind
+  pwd
+  ls
+  cd ..
+  #8 level behaind
+  pwd
+  ls
+  cd ..
+  #9 level behaind
+  pwd
+  ls
+  cd ..
+
    # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
 


### PR DESCRIPTION
What does this do?
- Allows accurics to do an IAC vulnerability scan on manifests made in terragrunt.
- Install the desired terragrunt version only if I select tgplan
- This does not include tgplanAll
- The url download.accurics was broken , right here we are using the new one.

In addition:
- Github clone by ssh compatibility 

Evidence of use
- Github action step implemented

![Screen Shot 2022-05-24 at 09 54 41](https://user-images.githubusercontent.com/19688747/170079448-5eb50911-9f13-4355-960e-9bbfceafa34f.png)

- Workflow running
![Screen Shot 2022-05-24 at 09 57 29](https://user-images.githubusercontent.com/19688747/170080061-140f1366-19ee-43a7-8a32-c70603fd69e0.png)